### PR TITLE
support username/password auth by adal lib

### DIFF
--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -355,11 +355,9 @@ class AzureRMModuleBase(object):
                 self.credentials.get('password') is not None and \
                 self.credentials.get('client_id') is not None:
                 tenant = self.credentials.get('tenant')
-                if not tenant:
-                    tenant = 'common'  # SDK default
 
                 self.azure_credentials = self.acquire_token_with_username_password(self._authority,
-                                                      self._resource
+                                                      self._resource,
                                                       self.credeitnals['ad_user'],
                                                       self.credentials['password'],
                                                       self.credentials['client_id'])

--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -340,36 +340,27 @@ class AzureRMModuleBase(object):
                                                                      verify=self._cert_validation_mode == 'validate')
 
         elif self.credentials.get('ad_user') is not None and \
-             self.credentials.get('password') is not None and \
-             self.credentials.get('client_id') is None:
+             self.credentials.get('password') is not None:
                 tenant = self.credentials.get('tenant')
                 if not tenant:
                     tenant = 'common'  # SDK default
 
-                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'],
-                                                             self.credentials['password'],
-                                                             tenant=tenant,
-                                                             cloud_environment=self._cloud_environment,
-                                                             verify=self._cert_validation_mode == 'validate')
-
-        elif self.credentials.get('ad_user') is not None and \
-             self.credentials.get('password') is not None and \
-             self.credentials.get('client_id') is not None:
-                tenant = self.credentials.get('tenant')
+                client_id = self.credentials.get('client_id')
+                if not client_id:
+                    client_id = '04b07795-8ddb-461a-bbee-02f9e1bf7b46'
 
                 self.azure_credentials = self.acquire_token_with_username_password(
                                                     self._authority,
                                                     self._resource,
                                                     self.credentials['ad_user'],
                                                     self.credentials['password'],
-                                                    '04b07795-8ddb-461a-bbee-02f9e1bf7b46',
+                                                    client_id,
                                                     tenant)
 
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
-                      "Credentials must include client_id, secret and tenant or ad_user and password and "
-                      "or ad_user and password and client_id and authority(optional) for ADFS or "
-                      "be logged in using AzureCLI.")
+                      "Credentials must include client_id, secret and tenant or ad_user and password "
+                      "or be logged in using AzureCLI.")
 
         # common parameter validation
         if self.module.params.get('tags'):

--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -356,11 +356,12 @@ class AzureRMModuleBase(object):
                 self.credentials.get('client_id') is not None:
                 tenant = self.credentials.get('tenant')
 
-                self.azure_credentials = self.acquire_token_with_username_password(self._authority,
-                                                      self._resource,
-                                                      self.credeitnals['ad_user'],
-                                                      self.credentials['password'],
-                                                      self.credentials['client_id'])
+                self.azure_credentials = self.acquire_token_with_username_password(
+                                                    self._authority,
+                                                    self._resource,
+                                                    self.credeitnals['ad_user'],
+                                                    self.credentials['password'],
+                                                    self.credentials['client_id'])
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password and "

--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -376,7 +376,6 @@ class AzureRMModuleBase(object):
             self.module.exit_json(**res)
 
     def acquire_token_with_username_password(self, authority, resource, username, password, client_id):
-        # not adfs, normal username password authentication
         context = AuthenticationContext(authority)
         token_response = context.acquire_token_with_username_password(resource, username, password, client_id)
 

--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -362,7 +362,7 @@ class AzureRMModuleBase(object):
                                                     self._resource,
                                                     self.credentials['ad_user'],
                                                     self.credentials['password'],
-                                                    self.credentials['client_id'],
+                                                    '04b07795-8ddb-461a-bbee-02f9e1bf7b46',
                                                     tenant)
 
         else:


### PR DESCRIPTION
update after last change:
- set default tenant
- set default client_id

merge into devel first to let user verify it again.