### PR TITLE
Allow multiple Functions to share the same Storage

### DIFF
--- a/library/azure_rm_functionapp.py
+++ b/library/azure_rm_functionapp.py
@@ -6,6 +6,8 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
+import random
+import string
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -271,7 +273,7 @@ class AzureRMFunctionApp(AzureRMModuleBase):
             function_app_settings.append(NameValuePair(name=key, value=self.storage_connection_string))
         function_app_settings.append(NameValuePair(name='FUNCTIONS_EXTENSION_VERSION', value='~1'))
         function_app_settings.append(NameValuePair(name='WEBSITE_NODE_DEFAULT_VERSION', value='6.5.0'))
-        function_app_settings.append(NameValuePair(name='WEBSITE_CONTENTSHARE', value=self.storage_account))
+        function_app_settings.append(NameValuePair(name='WEBSITE_CONTENTSHARE', value=self.storage_account + "".join(random.choice(string.ascii_lowercase) for _ in range(3))))
         return function_app_settings
 
     def aggregated_app_settings(self):


### PR DESCRIPTION
without this change, newly created functions using the same storage will overwrite each other / they are sharing the same container...