### PR TITLE
fix missing dependency

### DIFF
--- a/files/requirements-azure.txt
+++ b/files/requirements-azure.txt
@@ -1,4 +1,5 @@
 packaging
+xmltodict
 requests[security]
 azure-cli-core==2.0.35
 azure-cli-nspkg==3.0.2


### PR DESCRIPTION
fix missing dependency on xmltodict,  this is  used by webapp_facts. it's not necessary in upstream because it's already packaged.