### PR TITLE
adding devtest lab virtual network

### DIFF
--- a/library/azure_rm_devtestlab.py
+++ b/library/azure_rm_devtestlab.py
@@ -152,7 +152,7 @@ class AzureRMDevTestLab(AzureRMModuleBase):
 
         if self.lab.get('storage_type'):
             self.lab['storage_type'] = _snake_to_camel(self.lab['storage_type'], True)
-        if self.lab.get('premium_data_disks'):
+        if self.lab.get('premium_data_disks') is not None:
             self.lab['premium_data_disks'] = 'Enabled' if self.lab['premium_data_disks'] else 'Disabled'
 
         response = None

--- a/library/azure_rm_devtestlab.py
+++ b/library/azure_rm_devtestlab.py
@@ -151,7 +151,8 @@ class AzureRMDevTestLab(AzureRMModuleBase):
                 self.lab[key] = kwargs[key]
 
         if self.lab.get('storage_type'):
-            self.lab['storage_type'] = _snake_to_camel(self.lab['storage_type'], True)
+            self.lab['lab_storage_type'] = _snake_to_camel(self.lab['storage_type'], True)
+            self.lab.pop('storage_type', None)
         if self.lab.get('premium_data_disks') is not None:
             self.lab['premium_data_disks'] = 'Enabled' if self.lab['premium_data_disks'] else 'Disabled'
 
@@ -178,7 +179,7 @@ class AzureRMDevTestLab(AzureRMModuleBase):
             if self.state == 'absent':
                 self.to_do = Actions.Delete
             elif self.state == 'present':
-                if self.lab.get('storage_type') is not None and self.lab.get('storage_type').lower() != old_response.get('storage_type', '').lower():
+                if self.lab.get('lab_storage_type') is not None and self.lab.get('lab_storage_type').lower() != old_response.get('lab_storage_type', '').lower():
                     self.to_do = Actions.Update
                 if (self.lab.get('premium_data_disks') is not None and
                         self.lab.get('premium_data_disks').lower() != old_response.get('premium_data_disks').lower()):

--- a/library/azure_rm_devtestlab.py
+++ b/library/azure_rm_devtestlab.py
@@ -161,6 +161,10 @@ class AzureRMDevTestLab(AzureRMModuleBase):
                                                     base_url=self._cloud_environment.endpoints.resource_manager,
                                                     api_version='2018-10-15')
 
+        resource_group = self.get_resource_group(self.resource_group)
+        if self.lab.get('location') is None:
+            self.lab['location'] = resource_group.location
+
         old_response = self.get_devtestlab()
 
         if not old_response:

--- a/library/azure_rm_devtestlab.py
+++ b/library/azure_rm_devtestlab.py
@@ -46,7 +46,7 @@ options:
     state:
       description:
         - Assert the state of the DevTest Lab.
-        - Use 'present' to create or update an DevTest Lab and 'absent' to delete it.
+        - Use C(present) to create or update an DevTest Lab and C(absent) to delete it.
       default: present
       choices:
         - absent

--- a/library/azure_rm_devtestlab.py
+++ b/library/azure_rm_devtestlab.py
@@ -138,8 +138,8 @@ class AzureRMDevTestLab(AzureRMModuleBase):
         self.to_do = Actions.NoAction
 
         super(AzureRMDevTestLab, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                 supports_check_mode=True,
-                                                 supports_tags=True)
+                                                supports_check_mode=True,
+                                                supports_tags=True)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -180,7 +180,8 @@ class AzureRMDevTestLab(AzureRMModuleBase):
             elif self.state == 'present':
                 if self.lab.get('storage_type') is not None and self.lab.get('storage_type').lower() != old_response.get('storage_type', '').lower():
                     self.to_do = Actions.Update
-                if self.lab.get('premium_data_disks') is not None and self.lab.get('premium_data_disks').lower() != old_response.get('premium_data_disks').lower():
+                if (self.lab.get('premium_data_disks') is not None and
+                        self.lab.get('premium_data_disks').lower() != old_response.get('premium_data_disks').lower()):
                     self.to_do = Actions.Update
 
         if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
@@ -211,7 +212,7 @@ class AzureRMDevTestLab(AzureRMModuleBase):
         if self.state == 'present':
             self.results.update({
                 'id': response.get('id', None)
-                })
+            })
         return self.results
 
     def create_update_devtestlab(self):

--- a/library/azure_rm_devtestlabvirtualnetwork.py
+++ b/library/azure_rm_devtestlabvirtualnetwork.py
@@ -144,8 +144,8 @@ class AzureRMDevTestLabVirtualNetwork(AzureRMModuleBase):
         self.to_do = Actions.NoAction
 
         super(AzureRMDevTestLabVirtualNetwork, self).__init__(derived_arg_spec=self.module_arg_spec,
-                                                     supports_check_mode=True,
-                                                     supports_tags=True)
+                                                              supports_check_mode=True,
+                                                              supports_tags=True)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -207,7 +207,7 @@ class AzureRMDevTestLabVirtualNetwork(AzureRMModuleBase):
             self.results.update({
                 'id': response.get('id', None),
                 'external_provider_resource_id': response.get('external_provider_resource_id', None)
-                })
+            })
         return self.results
 
     def create_update_virtualnetwork(self):

--- a/library/azure_rm_devtestlabvirtualnetwork.py
+++ b/library/azure_rm_devtestlabvirtualnetwork.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Zim Kalinowski, <zikalino@microsoft.com>
+# Copyright (c) 2019 Zim Kalinowski, <zikalino@microsoft.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -73,8 +73,15 @@ id:
         - The identifier of the resource.
     returned: always
     type: str
-    sample: id
-external_provider_resource_id: external_vn_id
+    sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/testrg/providers/microsoft.devtestlab/
+             mylab/labzimsxxxabcmooo/virtualnetworks/myvn"
+external_provider_resource_id:
+    description:
+        - The identifier of external virtual network.
+    returned: always
+    type: str
+    sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/testrg/providers/Microsoft.Network/vi
+             rtualNetworks/myvn"
 '''
 
 import time
@@ -118,7 +125,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
             ),
             description=dict(
                 type='str'
-            )
+            ),
             state=dict(
                 type='str',
                 default='present',
@@ -169,8 +176,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
             if self.state == 'absent':
                 self.to_do = Actions.Delete
             elif self.state == 'present':
-                if self.virtual_network.get('description') is not None and
-                    self.virtual_network.get('description') != old_response.get('description'):
+                if self.virtual_network.get('description') is not None and self.virtual_network.get('description') != old_response.get('description'):
                     self.to_do = Actions.Update
 
         if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):

--- a/library/azure_rm_devtestlabvirtualnetwork.py
+++ b/library/azure_rm_devtestlabvirtualnetwork.py
@@ -1,0 +1,277 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2018 Zim Kalinowski, <zikalino@microsoft.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: azure_rm_devtestlabvirtualnetwork
+version_added: "2.8"
+short_description: Manage Azure DevTest Lab Virtual Network instance.
+description:
+    - Create, update and delete instance of DevTest Lab Virtual Network.
+
+options:
+    resource_group:
+        description:
+            - The name of the resource group.
+        required: True
+    lab_name:
+        description:
+            - The name of the lab.
+        required: True
+    name:
+        description:
+            - The name of the virtual network.
+        required: True
+    location:
+        description:
+            - The location of the resource.
+    description:
+        description:
+            - The description of the virtual network.
+    state:
+      description:
+        - Assert the state of the Virtual Network.
+        - Use 'present' to create or update an Virtual Network and 'absent' to delete it.
+      default: present
+      choices:
+        - absent
+        - present
+
+extends_documentation_fragment:
+    - azure
+    - azure_tags
+
+author:
+    - "Zim Kalinowski (@zikalino)"
+
+'''
+
+EXAMPLES = '''
+  - name: Create (or update) Virtual Network
+    azure_rm_devtestlabvirtualnetwork:
+      resource_group: testrg
+      lab_name: mylab
+      name: myvn
+      description: My Lab Virtual Network
+'''
+
+RETURN = '''
+id:
+    description:
+        - The identifier of the resource.
+    returned: always
+    type: str
+    sample: id
+external_provider_resource_id: external_vn_id
+'''
+
+import time
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+from ansible.module_utils.common.dict_transformations import _snake_to_camel
+
+try:
+    from msrestazure.azure_exceptions import CloudError
+    from msrest.polling import LROPoller
+    from msrestazure.azure_operation import AzureOperationPoller
+    from azure.mgmt.devtestlabs import DevTestLabsClient
+    from msrest.serialization import Model
+except ImportError:
+    # This is handled in azure_rm_common
+    pass
+
+
+class Actions:
+    NoAction, Create, Update, Delete = range(4)
+
+
+class AzureRMVirtualNetwork(AzureRMModuleBase):
+    """Configuration class for an Azure RM Virtual Network resource"""
+
+    def __init__(self):
+        self.module_arg_spec = dict(
+            resource_group=dict(
+                type='str',
+                required=True
+            ),
+            lab_name=dict(
+                type='str',
+                required=True
+            ),
+            name=dict(
+                type='str',
+                required=True
+            ),
+            location=dict(
+                type='str'
+            ),
+            description=dict(
+                type='str'
+            )
+            state=dict(
+                type='str',
+                default='present',
+                choices=['present', 'absent']
+            )
+        )
+
+        self.resource_group = None
+        self.lab_name = None
+        self.name = None
+        self.virtual_network = {}
+
+        self.results = dict(changed=False)
+        self.mgmt_client = None
+        self.state = None
+        self.to_do = Actions.NoAction
+
+        super(AzureRMVirtualNetwork, self).__init__(derived_arg_spec=self.module_arg_spec,
+                                                     supports_check_mode=True,
+                                                     supports_tags=True)
+
+    def exec_module(self, **kwargs):
+        """Main module execution method"""
+
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            if hasattr(self, key):
+                setattr(self, key, kwargs[key])
+            elif kwargs[key] is not None:
+                self.virtual_network[key] = kwargs[key]
+
+        response = None
+
+        self.mgmt_client = self.get_mgmt_svc_client(DevTestLabsClient,
+                                                    base_url=self._cloud_environment.endpoints.resource_manager)
+
+        resource_group = self.get_resource_group(self.resource_group)
+
+        old_response = self.get_virtualnetwork()
+
+        if not old_response:
+            self.log("Virtual Network instance doesn't exist")
+            if self.state == 'absent':
+                self.log("Old instance didn't exist")
+            else:
+                self.to_do = Actions.Create
+        else:
+            self.log("Virtual Network instance already exists")
+            if self.state == 'absent':
+                self.to_do = Actions.Delete
+            elif self.state == 'present':
+                if self.virtual_network.get('description') is not None and
+                    self.virtual_network.get('description') != old_response.get('description'):
+                    self.to_do = Actions.Update
+
+        if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
+            self.log("Need to Create / Update the Virtual Network instance")
+
+            if self.check_mode:
+                self.results['changed'] = True
+                return self.results
+
+            response = self.create_update_virtualnetwork()
+
+            self.results['changed'] = True
+            self.log("Creation / Update done")
+        elif self.to_do == Actions.Delete:
+            self.log("Virtual Network instance deleted")
+            self.results['changed'] = True
+
+            if self.check_mode:
+                return self.results
+
+            self.delete_virtualnetwork()
+            # This currently doesnt' work as there is a bug in SDK / Service
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
+                response = self.get_poller_result(response)
+        else:
+            self.log("Virtual Network instance unchanged")
+            self.results['changed'] = False
+            response = old_response
+
+        if self.state == 'present':
+            self.results.update({
+                'id': response.get('id', None),
+                'external_provider_resource_id': response.get('external_provider_resource_id', None)
+                })
+        return self.results
+
+    def create_update_virtualnetwork(self):
+        '''
+        Creates or updates Virtual Network with the specified configuration.
+
+        :return: deserialized Virtual Network instance state dictionary
+        '''
+        self.log("Creating / Updating the Virtual Network instance {0}".format(self.name))
+
+        try:
+            response = self.mgmt_client.virtual_networks.create_or_update(resource_group_name=self.resource_group,
+                                                                          lab_name=self.lab_name,
+                                                                          name=self.name,
+                                                                          virtual_network=self.virtual_network)
+            if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
+                response = self.get_poller_result(response)
+
+        except CloudError as exc:
+            self.log('Error attempting to create the Virtual Network instance.')
+            self.fail("Error creating the Virtual Network instance: {0}".format(str(exc)))
+        return response.as_dict()
+
+    def delete_virtualnetwork(self):
+        '''
+        Deletes specified Virtual Network instance in the specified subscription and resource group.
+
+        :return: True
+        '''
+        self.log("Deleting the Virtual Network instance {0}".format(self.name))
+        try:
+            response = self.mgmt_client.virtual_networks.delete(resource_group_name=self.resource_group,
+                                                                lab_name=self.lab_name,
+                                                                name=self.name)
+        except CloudError as e:
+            self.log('Error attempting to delete the Virtual Network instance.')
+            self.fail("Error deleting the Virtual Network instance: {0}".format(str(e)))
+
+        return True
+
+    def get_virtualnetwork(self):
+        '''
+        Gets the properties of the specified Virtual Network.
+
+        :return: deserialized Virtual Network instance state dictionary
+        '''
+        self.log("Checking if the Virtual Network instance {0} is present".format(self.name))
+        found = False
+        try:
+            response = self.mgmt_client.virtual_networks.get(resource_group_name=self.resource_group,
+                                                             lab_name=self.lab_name,
+                                                             name=self.name)
+            found = True
+            self.log("Response : {0}".format(response))
+            self.log("Virtual Network instance : {0} found".format(response.name))
+        except CloudError as e:
+            self.log('Did not find the Virtual Network instance.')
+        if found is True:
+            return response.as_dict()
+
+        return False
+
+
+def main():
+    """Main execution"""
+    AzureRMVirtualNetwork()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/azure_rm_devtestlabvirtualnetwork.py
+++ b/library/azure_rm_devtestlabvirtualnetwork.py
@@ -19,7 +19,7 @@ module: azure_rm_devtestlabvirtualnetwork
 version_added: "2.8"
 short_description: Manage Azure DevTest Lab Virtual Network instance.
 description:
-    - Create, update and delete instance of DevTest Lab Virtual Network.
+    - Create, update and delete instance of Azure DevTest Lab Virtual Network.
 
 options:
     resource_group:
@@ -74,7 +74,7 @@ id:
     returned: always
     type: str
     sample: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/testrg/providers/microsoft.devtestlab/
-             mylab/labzimsxxxabcmooo/virtualnetworks/myvn"
+             mylab/mylab/virtualnetworks/myvn"
 external_provider_resource_id:
     description:
         - The identifier of external virtual network.
@@ -103,7 +103,7 @@ class Actions:
     NoAction, Create, Update, Delete = range(4)
 
 
-class AzureRMVirtualNetwork(AzureRMModuleBase):
+class AzureRMDevTestLabVirtualNetwork(AzureRMModuleBase):
     """Configuration class for an Azure RM Virtual Network resource"""
 
     def __init__(self):
@@ -143,7 +143,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        super(AzureRMVirtualNetwork, self).__init__(derived_arg_spec=self.module_arg_spec,
+        super(AzureRMDevTestLabVirtualNetwork, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                      supports_check_mode=True,
                                                      supports_tags=True)
 
@@ -159,9 +159,12 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
         response = None
 
         self.mgmt_client = self.get_mgmt_svc_client(DevTestLabsClient,
-                                                    base_url=self._cloud_environment.endpoints.resource_manager)
+                                                    base_url=self._cloud_environment.endpoints.resource_manager,
+                                                    api_version='2018-10-15')
 
         resource_group = self.get_resource_group(self.resource_group)
+        if self.virtual_network.get('location') is None:
+            self.virtual_network['location'] = resource_group.location
 
         old_response = self.get_virtualnetwork()
 
@@ -181,22 +184,16 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
 
         if (self.to_do == Actions.Create) or (self.to_do == Actions.Update):
             self.log("Need to Create / Update the Virtual Network instance")
-
-            if self.check_mode:
-                self.results['changed'] = True
-                return self.results
-
-            response = self.create_update_virtualnetwork()
-
             self.results['changed'] = True
+            if self.check_mode:
+                return self.results
+            response = self.create_update_virtualnetwork()
             self.log("Creation / Update done")
         elif self.to_do == Actions.Delete:
             self.log("Virtual Network instance deleted")
             self.results['changed'] = True
-
             if self.check_mode:
                 return self.results
-
             self.delete_virtualnetwork()
             # This currently doesnt' work as there is a bug in SDK / Service
             if isinstance(response, LROPoller) or isinstance(response, AzureOperationPoller):
@@ -276,7 +273,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
 
 def main():
     """Main execution"""
-    AzureRMVirtualNetwork()
+    AzureRMDevTestLabVirtualNetwork()
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/azure_rm_devtestlab/aliases
+++ b/tests/integration/targets/azure_rm_devtestlab/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 destructive
 shippable/azure/group1
+azure_rm_devtestlabvirtualnetwork

--- a/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -56,6 +56,45 @@
     that:
       - output.changed
 
+- name: Create instance of DebTest Labs virtual network
+  azure_rm_devtestlabvirtualnetwork:
+    resource_group: "{{ resource_group }}"
+    lab_name: "lab{{ rpfx}}"
+    name: "vn{{ rpfx }}"
+    location: eastus
+    description: My DevTest Lab
+  register: output
+- name: Assert the change was registered
+  assert:
+    that:
+      - output.changed
+
+- name: Update instance of DebTest Labs with same parameters
+  azure_rm_devtestlabvirtualnetwork:
+    resource_group: "{{ resource_group }}"
+    lab_name: "lab{{ rpfx}}"
+    name: "vn{{ rpfx }}"
+    location: eastus
+    description: My DevTest Lab
+  register: output
+- name: Assert that nothing was changed
+  assert:
+    that:
+      - output.changed == false
+
+- name: Update instance of DebTest Labs with changed description
+  azure_rm_devtestlabvirtualnetwork:
+    resource_group: "{{ resource_group }}"
+    lab_name: "lab{{ rpfx}}"
+    name: "vn{{ rpfx }}"
+    location: eastus
+    description: My DevTest Lab Updated
+  register: output
+- name: Assert that nothing was changed
+  assert:
+    that:
+      - output.changed
+
 - name: Delete instance of Lab -- check mode
   azure_rm_devtestlab:
     resource_group: "{{ resource_group }}"

--- a/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -70,7 +70,7 @@
     that:
       - output.changed
 
-- name: Update instance of DebTest Labs with same parameters
+- name: Update instance of DebTest Labs virtual network with same parameters
   azure_rm_devtestlabvirtualnetwork:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
@@ -83,7 +83,7 @@
     that:
       - output.changed == false
 
-- name: Update instance of DebTest Labs with changed description
+- name: Update instance of DebTest Labs virtual network with changed description
   azure_rm_devtestlabvirtualnetwork:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"

--- a/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/tests/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Prepare random number
   set_fact:
     lab_name: "lab{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
+    vn_name: "vn{{ resource_group | hash('md5') | truncate(7, True, '') }}{{ 1000 | random }}"
   run_once: yes
 
 - name: Create instance of Lab -- check mode
@@ -59,8 +60,8 @@
 - name: Create instance of DebTest Labs virtual network
   azure_rm_devtestlabvirtualnetwork:
     resource_group: "{{ resource_group }}"
-    lab_name: "lab{{ rpfx}}"
-    name: "vn{{ rpfx }}"
+    lab_name: "{{ lab_name }}"
+    name: "{{ vn_name }}"
     location: eastus
     description: My DevTest Lab
   register: output
@@ -72,8 +73,8 @@
 - name: Update instance of DebTest Labs with same parameters
   azure_rm_devtestlabvirtualnetwork:
     resource_group: "{{ resource_group }}"
-    lab_name: "lab{{ rpfx}}"
-    name: "vn{{ rpfx }}"
+    lab_name: "{{ lab_name }}"
+    name: "{{ vn_name }}"
     location: eastus
     description: My DevTest Lab
   register: output
@@ -85,8 +86,8 @@
 - name: Update instance of DebTest Labs with changed description
   azure_rm_devtestlabvirtualnetwork:
     resource_group: "{{ resource_group }}"
-    lab_name: "lab{{ rpfx}}"
-    name: "vn{{ rpfx }}"
+    lab_name: "{{ lab_name }}"
+    name: "{{ vn_name }}"
     location: eastus
     description: My DevTest Lab Updated
   register: output


### PR DESCRIPTION
This is basic implementation of DevTest Lab Virtual Network.
In basic implementation default virtual network is created.
In more advanced scenario user should be able to refer external Virtual Network resource, and then override it's subnet, but that's pretty complex scenario so I am leaving it for later.
