### PR TITLE
Add cloud platform metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,3 +28,6 @@ galaxy_info:
     - name: Windows
       versions:
         - 2012R2
+
+  cloud_platforms:
+    - Azure


### PR DESCRIPTION
At the right bottom of the [galaxy hub](https://galaxy.ansible.com/search?deprecated=false&order_by=-relevance&keywords=), user can select the cloud  filter