### PR TITLE
add condition for http status code

### DIFF
--- a/lookup_plugins/azure_keyvault_secret.py
+++ b/lookup_plugins/azure_keyvault_secret.py
@@ -106,6 +106,8 @@ try:
             TOKEN_ACQUIRED = True
         else:
             display.v('Successfully called MSI endpoint, but no token was available. Will use service principal if provided.')
+    else:
+        display.v("Unable to query MSI endpoint, Error Code %s. Will use service principal if provided" % token_res.status_code)
 except requests.exceptions.RequestException:
     display.v('Unable to fetch MSI token. Will use service principal if provided.')
     TOKEN_ACQUIRED = False

--- a/lookup_plugins/azure_keyvault_secret.py
+++ b/lookup_plugins/azure_keyvault_secret.py
@@ -100,11 +100,12 @@ token_headers = {
 token = None
 try:
     token_res = requests.get('http://169.254.169.254/metadata/identity/oauth2/token', params=token_params, headers=token_headers)
-    token = token_res.json().get("access_token")
-    if token is not None:
-        TOKEN_ACQUIRED = True
-    else:
-        display.v('Successfully called MSI endpoint, but no token was available. Will use service principal if provided.')
+    if token_res.ok:
+        token = token_res.json().get("access_token")
+        if token is not None:
+            TOKEN_ACQUIRED = True
+        else:
+            display.v('Successfully called MSI endpoint, but no token was available. Will use service principal if provided.')
 except requests.exceptions.RequestException:
     display.v('Unable to fetch MSI token. Will use service principal if provided.')
     TOKEN_ACQUIRED = False


### PR DESCRIPTION
ensure that token_res returns a successful http status code before accessing the response

References
* https://github.com/Azure/azure_preview_modules/issues/336
* https://github.com/Azure/azure_preview_modules/issues/336#issuecomment-575235510