### PR TITLE
Support azure cli credentials with multiple `subscription_id`s

### DIFF
--- a/module_utils/azure_rm_common.py
+++ b/module_utils/azure_rm_common.py
@@ -266,7 +266,7 @@ except ImportError:
 
 try:
     from azure.cli.core.util import CLIError
-    from azure.common.credentials import get_azure_cli_credentials, get_cli_profile
+    from azure.common.credentials import get_cli_profile
     from azure.common.cloud import get_cli_active_cloud
 except ImportError:
     HAS_AZURE_CLI_CORE = False
@@ -1355,8 +1355,10 @@ class AzureRMAuth(object):
             'subscription_id': subscription_id
         }
 
-    def _get_azure_cli_credentials(self):
-        credentials, subscription_id = get_azure_cli_credentials()
+    def _get_azure_cli_credentials(self, subscription_id_param=None):
+        subscription_id = subscription_id_param or os.environ.get(AZURE_CREDENTIAL_ENV_MAPPING['subscription_id'], None)
+        profile = get_cli_profile()
+        credentials, subscription_id, tenant = profile.get_login_credentials(subscription_id=subscription_id)
         cloud_environment = get_cli_active_cloud()
 
         cli_credentials = {
@@ -1403,7 +1405,7 @@ class AzureRMAuth(object):
                           exception=HAS_AZURE_CLI_CORE_EXC)
             try:
                 self.log('Retrieving credentials from Azure CLI profile')
-                cli_credentials = self._get_azure_cli_credentials()
+                cli_credentials = self._get_azure_cli_credentials(arg_credentials['subscription_id'])
                 return cli_credentials
             except CLIError as err:
                 self.fail("Azure CLI profile cannot be loaded - {0}".format(err))
@@ -1419,14 +1421,14 @@ class AzureRMAuth(object):
             default_credentials = self._get_profile(profile)
             return default_credentials
 
-        # auto, precedence: module parameters -> environment variables -> default profile in ~/.azure/credentials
+        # auto, precedence: module parameters -> environment variables -> default profile in ~/.azure/credentials -> azure cli
         # try module params
         if arg_credentials['profile'] is not None:
             self.log('Retrieving credentials with profile parameter.')
             credentials = self._get_profile(arg_credentials['profile'])
             return credentials
 
-        if arg_credentials['subscription_id']:
+        if arg_credentials['client_id'] or arg_credentials['ad_user']:
             self.log('Received credentials from parameters.')
             return arg_credentials
 
@@ -1445,7 +1447,7 @@ class AzureRMAuth(object):
         try:
             if HAS_AZURE_CLI_CORE:
                 self.log('Retrieving credentials from AzureCLI profile')
-            cli_credentials = self._get_azure_cli_credentials()
+            cli_credentials = self._get_azure_cli_credentials(arg_credentials['subscription_id'])
             return cli_credentials
         except CLIError as ce:
             self.log('Error getting AzureCLI profile credentials - {0}'.format(ce))


### PR DESCRIPTION
This is the same change I have a pull request for at the Ansible main repository, but it isn't entirely clear what the correct path for new changes is for the Azure Ansible modules.

See original pull request: https://github.com/ansible/ansible/pull/65331

I also couldn't find the `doc_fragments` part from the original change, so this change doesn't update the documentation, which the original does.

Also relates to these issues/pull requests in the main Ansible repository:

- https://github.com/ansible/ansible/pull/48089
- https://github.com/ansible/ansible/issues/63182

Below is the text from the pull request against the main Ansible repository:

##### SUMMARY
When using credentials obtained from the azure cli only the default subscription can be used, even though the azure cli is authenticated for multiple subscriptions.

This change passes any optionally specified `subscription_id` (similar to how it's done for `auth_source: msi`) along when requesting the azure cli credentials. If none is specified it falls back to the current behaviour of selecting the default subscription.

The only other change that had to be made was in the `auth_source: auto` case where we would always assume that all credential information is passed using arguments when `subscription_id` is set. I changed this to check the fields that actually refer to specific credentials (namely `client_id` (for service principals) and `ad_user` (for user names)). This way we still fall through to the azure cli method, eventhough only `subscription_id` is explicitly set.

Fixes #321 
Fixes [`ansible#63182`](https://github.com/ansible/ansible/issues/63182)

This effectively fixes the same problem as [`ansible#48089`](https://github.com/ansible/ansible/pull/48089) is trying to fix, only in a way that is more consistent with how credentials and subscription id's are determined for other `auth_source`s. This was one of the main criticisms that's probably holding that pull request up.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ADDITIONAL INFORMATION
We have different Azure subscriptions for our prod and dev environments. By default we only work on the dev environment, but we have a number of playbooks that we want to work with all virtual machines at once.

Demonstration playbook:
```
- name: Get azure vm info from different subscriptions
  hosts: localhost
  tasks:
  - azure_rm_virtualmachine_info:
      name: prod-db
      resource_group: prod
      subscription_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
      auth_source: cli
  - azure_rm_virtualmachine_info:
      name: dev-db
      resource_group: dev
      subscription_id: YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY
      auth_source: cli
```

Before:
```
$ ansible-playbook playbooks/az_info.yml

PLAY [Get azure vm info from different subscriptions] *********************************************************************************

TASK [azure_rm_virtualmachine_info] ***************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  msg: |-
    Error getting virtual machine prod-db - Azure Error: ResourceGroupNotFound
    Message: Resource group 'prod' could not be found.

PLAY RECAP ****************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

After:
```
$ ansible-playbook playbooks/az_info.yml

PLAY [Get azure vm info from different subscriptions] *********************************************************************************

TASK [azure_rm_virtualmachine_info] ***************************************************************************************************
ok: [localhost]

TASK [azure_rm_virtualmachine_info] ***************************************************************************************************
ok: [localhost]

PLAY RECAP ****************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```