### PR TITLE
Fixing the semantic of skip_azure_sdk

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   pip:
     requirements: "{{ role_path }}/files/requirements-azure.txt"
     extra_args: -I
-  when: skip_azure_sdk
+  when: (skip_azure_sdk is undefined) or (not skip_azure_sdk)
 
 - debug:
     msg:


### PR DESCRIPTION
I believe the previous condition was reversed (ie, it would only run if skip_azure_sdk was set to true, which means it would be run most of the time because the default setting is set to true).