### PR TITLE
Fix example

### DIFF
--- a/lookup_plugins/azure_keyvault_secret.py
+++ b/lookup_plugins/azure_keyvault_secret.py
@@ -46,7 +46,7 @@ EXAMPLE = """
     client_id: '123456789'
     secret: 'abcdefg'
     tenant: 'uvwxyz'
-  debug: msg="the value of this secret is {{lookup('azure_keyvault_secret',secretname,vault_url=url, cliend_id=client_id, secret=secret, tenant_id=tenant)}}"
+  debug: msg="the value of this secret is {{lookup('azure_keyvault_secret',secretname,vault_url=url, client_id=client_id, secret=secret, tenant_id=tenant)}}"
 
 # Example below creates an Azure Virtual Machine with SSH public key from key vault using 'azure_keyvault_secret' lookup plugin.
 - name: Create Azure VM


### PR DESCRIPTION
huh, that was a tricky one:

```msg": "An unhandled exception occurred while running the lookup plugin 'azure_keyvault_secret'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Invalid credentials provided."
```

only when you debug it at low level (module code) you can see:
```
msg": "An unhandled exception occurred while running the lookup plugin 'azure_keyvault_secret'. Error was a <class 'msrest.exceptions.AuthenticationError'>, original message: , AdalError: Get Token request returned http error: 400 and server response: {\"error\":\"invalid_request\",\"error_description\":\"AADSTS900144: The request body must contain the following parameter: 'client_id'.
```