### PR TITLE
Fixing rule_type reference

### DIFF
--- a/library/azure_rm_appgateway.py
+++ b/library/azure_rm_appgateway.py
@@ -739,7 +739,7 @@ class AzureRMApplicationGateways(AzureRMModuleBase):
                             item['http_listener'] = {'id': id}
                         if 'protocol' in item:
                             item['protocol'] = _snake_to_camel(item['protocol'], True)
-                        if 'rule_type' in ev:
+                        if 'rule_type' in item:
                             item['rule_type'] = _snake_to_camel(item['rule_type'], True)
                         if 'redirect_configuration' in item:
                             id = redirect_configuration_id(self.subscription_id,


### PR DESCRIPTION
Summary: 
When reviewing https://github.com/ansible/ansible/issues/68744 , I found that the "rule_type" if statement checks 'ev' instead of 'item'. This is preventing it from being parsed properly, and the _snake_to_camel function isn't triggered to filter the options into the desired format. 

Links:
Reference: https://github.com/Azure/azure_preview_modules/blob/master/library/azure_rm_appgateway.py#L742

Importing the function: 					https://github.com/Azure/azure_preview_modules/blob/master/library/azure_rm_appgateway.py#L443

Source for _snake_to_camel: 
https://github.com/Azure/azure_preview_modules/blob/2413dafa6f979a2070843b073830901cc1b1d868/module_utils/common/dict_transformations.py#L77

Testing: 
```
Before: 
"msg": "Error creating the Application Gateway instance: Azure Error: InvalidRequestFormat\nMessage: Cannot parse the request.\nException Details:\n\tError Code: InvalidJson\n\tMessage: Error converting value \"path_based_routing\" to type 'Microsoft.WindowsAzure.Networking.Nrp.Frontend.Contract.Csm.Public.ApplicationGatewayRequestRoutingRuleType'. Path 'properties.requestRoutingRules[0].properties.ruleType', line 1, position 1565."
}

After: 
TASK [Create instance of Application Gateway] ************************************************************************************************************************************************
task path: /home/zephyr/azure/aztest.yml:7

```