### PR TITLE
Fix #389 : Replace check with Ansible version comparison

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,4 @@
       - "or"
       - "  pip install --user -r {{ role_path }}/files/requirements-azure.txt"
       - "depending on your ansible setup."
-  when: ansible_version.full < "2.5.0"
+  when: ansible_version.full is version('2.5.0', '<')


### PR DESCRIPTION
Fix for #389. The String comparison method was broken when the Ansible version rolled over to 2.10.0, since it was comparing Strings rather than version numbers.

Ansible's version comparison function (https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#comparing-versions) fixes this issue.

Will also resolve https://github.com/Azure-Samples/ansible-playbooks/issues/88, which depends on this role.